### PR TITLE
Forward all args after the first two to python

### DIFF
--- a/runcython
+++ b/runcython
@@ -14,7 +14,7 @@ runcython () {
     PYTHONPATH=$tmpdir:$PYTHONPATH python -c "
 import $BASE_NAME
 if hasattr($BASE_NAME, 'main'):
-    $BASE_NAME.main()"
+    $BASE_NAME.main()" "${@:4}"
 }
 
 runcython "$@"


### PR DESCRIPTION
The first two args are already used for cython and the compiler, respectively. The rest should be forwarded so that the following commands do the same thing:  
python hello.py arg1 arg2
runcython3 hello.pyx '' '' arg1 arg2